### PR TITLE
remove promiscuos mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,6 @@ If the VLAN0 traffic is being properly handled, next pfSense will need to reques
 
 If you don't see traffic being bridged between `ngeth0` and `$ONT_IF`, then netgraph is not setup correctly. 
 
-## Promiscuous Mode
-
-`pfatt.sh` will put `$RG_IF` in promiscuous mode via `/sbin/ifconfig $RG_IF promisc`. Otherwise, the EAP packets would not bridge. I think this is necessary for everyone but I'm not sure. Turn it off if it's casuing issues. 
-
 ## netgraph
 
 The netgraph system provides a uniform and modular system for the implementation of kernel objects which perform various networking functions. If you're unfamilar with netgraph, this [tutorial](http://www.netbsd.org/gallery/presentations/ast/2012_AsiaBSDCon/Tutorial_NETGRAPH.pdf) is a great introduction. 

--- a/bin/pfatt.sh
+++ b/bin/pfatt.sh
@@ -65,6 +65,14 @@ echo -n "  removing waneapfilter:nomatch hook... "
 /usr/sbin/ngctl rmhook waneapfilter: nomatch
 echo "OK!"
 
+echo -n "setting $RG_IF MAC address to match RG ($RG_ETHER_ADDR)... "
+/sbin/ifconfig $RG_IF ether $RG_ETHER_ADDR
+echo "OK!"
+
+echo -n "setting $ONT_IF MAC address to match RG ($RG_ETHER_ADDR)... "
+/sbin/ifconfig $ONT_IF ether $RG_ETHER_ADDR
+echo "OK!"
+
 echo "enabling interfaces..."
 echo -n "  $RG_IF ... "
 /sbin/ifconfig $RG_IF up
@@ -74,12 +82,8 @@ echo -n "  $ONT_IF ... "
 /sbin/ifconfig $ONT_IF up
 echo "OK!"
 
-echo -n "enabling promiscuous mode on $RG_IF... "
-/sbin/ifconfig $RG_IF promisc
-echo "OK!"
-
-echo -n "enabling promiscuous mode on $ONT_IF... "
-/sbin/ifconfig $ONT_IF promisc
+echo -n "  ngeth0 ... "
+/sbin/ifconfig ngeth0 up
 echo "OK!"
 
 echo "ngeth0 should now be available to configure as your pfSense WAN"


### PR DESCRIPTION
If we set each involved interface to match the RG MAC, we don't need promiscuous mode. This may help with performance.