### PR TITLE
Update pfatt.sh

### DIFF
--- a/bin/pfatt.sh
+++ b/bin/pfatt.sh
@@ -24,6 +24,7 @@ getTimestamp(){
     echo "OK!"
 
     if [ ${OPNSENSE} != 'yes' ]; then
+        /sbin/kldload -nq ng_ether
         echo -n "$(getTimestamp) attaching interfaces to ng_ether... "
         /usr/local/bin/php -r "pfSense_ngctl_attach('.', '$ONT_IF');" 
         /usr/local/bin/php -r "pfSense_ngctl_attach('.', '$RG_IF');"


### PR DESCRIPTION
The ng_ether module doesn't automatically load on OPNsense 20.1, this then causes the whole script to fail because the NICs were never attached to netgraph.