### PR TITLE
use bash instead of sh in gen-duid.sh

### DIFF
--- a/bin/gen-duid.sh
+++ b/bin/gen-duid.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ascii2hex() { echo -n "$*" | awk 'BEGIN{for(n=0;n<256;n++)ord[sprintf("%c",n)]=n}{len=split($0,c,"");for(i=1;i<=len;i++)printf("%x",ord[c[i]])}'; }
 
 printhexstring() { awk '{l=split($0,c,"");for(i=1;i<l-1;i=i+2)printf("%s:",substr($0,i,2));print(substr($0,l-1,2))}'; }


### PR DESCRIPTION
On Mac at least, the `echo` implementation in the `sh` shell does not support the `-n` flag, so the output of `gen-duid.sh` is both poorly formatted and incorrect (it includes the "-n" in the string that is echoed, somewhat horribly). It seems to be fixed by using bash.

```
$ sh -c "echo -n hello"
-n hello
$ bash -c "echo -n hello"
hello$ 
```
