### PR TITLE
Restructured netgraph: removed one2many and added new eiface to serve DHCP to gateway

### DIFF
--- a/bin/pfatt.sh
+++ b/bin/pfatt.sh
@@ -20,7 +20,10 @@ getTimestamp(){
     echo "$(getTimestamp)      OPNSENSE: $OPNSENSE"
 
     echo -n "$(getTimestamp) loading netgraph kernel modules... "
+    /sbin/kldload -nq netgraph
+    /sbin/kldload -nq ng_ether
     /sbin/kldload -nq ng_etf
+    /sbin/kldload -nq ng_vlan
     echo "OK!"
 
     if [ ${OPNSENSE} != 'yes' ]; then
@@ -32,47 +35,29 @@ getTimestamp(){
 
     echo "$(getTimestamp) building netgraph nodes..."
 
-    echo -n "$(getTimestamp)   creating ng_one2many... "
-    /usr/sbin/ngctl mkpeer $ONT_IF: one2many lower one
-    /usr/sbin/ngctl name $ONT_IF:lower o2m
+    echo -n "$(getTimestamp) bridging EAPOL packets between $ONT_IF (ONT) and $RG_IF (RG)... "
+    /usr/sbin/ngctl mkpeer $ONT_IF: etf lower downstream
+    /usr/sbin/ngctl name $ONT_IF:lower ont-eap
+    /usr/sbin/ngctl mkpeer $RG_IF: etf lower downstream
+    /usr/sbin/ngctl name $RG_IF:lower rg-eap
+    /usr/sbin/ngctl connect ont-eap: rg-eap: eap eap
+    /usr/sbin/ngctl msg ont-eap: 'setfilter {ethertype=0x888e matchhook="eap"}'
+    /usr/sbin/ngctl msg rg-eap: 'setfilter {ethertype=0x888e matchhook="eap"}'
     echo "OK!"
 
-    echo -n "$(getTimestamp)   creating vlan node and interface... "
-    /usr/sbin/ngctl mkpeer o2m: vlan many0 downstream
-    /usr/sbin/ngctl name o2m:many0 vlan0
-    /usr/sbin/ngctl mkpeer vlan0: eiface vlan0 ether
-
-    /usr/sbin/ngctl msg vlan0: 'addfilter { vlan=0 hook="vlan0" }'
+    echo -n "$(getTimestamp) untagging other packets on $ONT_IF (ONT) to ngeth0"
+    /usr/sbin/ngctl mkpeer ont-eap: vlan nomatch downstream
+    /usr/sbin/ngctl name ont-eap:nomatch ont-vl0
+    /usr/sbin/ngctl mkpeer ont-vl0: eiface vl0 ether
+    /usr/sbin/ngctl msg ont-vl0: 'addfilter {vid=0 hook="vl0"}'
     /usr/sbin/ngctl msg ngeth0: set $RG_ETHER_ADDR
     echo "OK!"
 
-    echo -n "$(getTimestamp)   defining etf for $ONT_IF (ONT)... "
-    /usr/sbin/ngctl mkpeer o2m: etf many1 downstream
-    /usr/sbin/ngctl name o2m:many1 waneapfilter
-    /usr/sbin/ngctl connect waneapfilter: $ONT_IF: nomatch upper
-    echo "OK!"
-
-    echo -n "$(getTimestamp)   defining etf for $RG_IF (RG)... "
-    /usr/sbin/ngctl mkpeer $RG_IF: etf lower downstream
-    /usr/sbin/ngctl name $RG_IF:lower laneapfilter
-    /usr/sbin/ngctl connect laneapfilter: $RG_IF: nomatch upper
-    echo "OK!"
-
-    echo -n "$(getTimestamp)   bridging etf for $ONT_IF <-> $RG_IF... "
-    /usr/sbin/ngctl connect waneapfilter: laneapfilter: eapout eapout
-    echo "OK!"
-
-    echo -n "$(getTimestamp)   defining filters for EAP traffic... "
-    /usr/sbin/ngctl msg waneapfilter: 'setfilter { matchhook="eapout" ethertype=0x888e }'
-    /usr/sbin/ngctl msg laneapfilter: 'setfilter { matchhook="eapout" ethertype=0x888e }'
-    echo "OK!"
-
-    echo -n "$(getTimestamp)   enabling one2many links... "
-    /usr/sbin/ngctl msg o2m: setconfig "{ xmitAlg=2 failAlg=1 enabledLinks=[ 1 1 ] }"
-    echo "OK!"
-
-    echo -n "$(getTimestamp)   removing waneapfilter:nomatch hook... "
-    /usr/sbin/ngctl rmhook waneapfilter: nomatch
+    echo -n "$(getTimestamp) untagging other packets on $RG_IF (RG) to ngeth1"
+    /usr/sbin/ngctl mkpeer rg-eap: vlan nomatch downstream
+    /usr/sbin/ngctl name rg-eap:nomatch rg-vl0
+    /usr/sbin/ngctl mkpeer rg-vl0: eiface vl0 ether
+    /usr/sbin/ngctl msg rg-vl0: 'addfilter {vid=0 hook="vl0"}'
     echo "OK!"
 
     echo -n "$(getTimestamp) enabling $RG_IF interface... "


### PR DESCRIPTION
Restructed netgraph by connecting ngeth0 directly to etf nomatch hook
(normal, non-EAPOL traffic) and removed one2many node

Added ngeth1 node on AT&T gateway interface for normal, non-EAPOL traffic to
allow serving DHCP requests from the gateway by pf/OPNsese and make the
Broadband light stop blinking

Added all required kernal modules for OPNsense 20.1 compatibility